### PR TITLE
fix Connection unexpectedly closed for emails with simple text format…

### DIFF
--- a/lathermail/mail.py
+++ b/lathermail/mail.py
@@ -19,6 +19,10 @@ def convert_addresses(raw_header):
 
 
 def convert_message_to_dict(to, sender, message, body, user, password):
+    if message["From"] is None:
+        message["From"] = sender
+    if message["To"] is None:
+        message["To"] = ','.join(to)
     result = {
         "inbox": user,
         "password": password,


### PR DESCRIPTION
…: without From and To in body

proof code for python 2.7

```python
import smtplib

URL = 'localhost' 
PORT = 2525
server = smtplib.SMTP(URL,PORT)
res = server.login('aa@aaa.com','a123')
msg = 'message'
from_e = 'aa@aa.com'
to_e = 'bb@aa.com'
server.sendmail(from_e, to_e, msg)
```

result:
```
Traceback (most recent call last):
  File "check_mail.py", line 18, in <module>
    server.sendmail(from_e, to_e, "msg.as_string()")
  File "C:\Anaconda\lib\smtplib.py", line 743, in sendmail
    (code, resp) = self.data(msg)
  File "C:\Anaconda\lib\smtplib.py", line 511, in data
    (code, msg) = self.getreply()
  File "C:\Anaconda\lib\smtplib.py", line 368, in getreply
    raise SMTPServerDisconnected("Connection unexpectedly closed")
smtplib.SMTPServerDisconnected: Connection unexpectedly closed
```